### PR TITLE
Use smaller clone session ID

### DIFF
--- a/p4src/max.p4
+++ b/p4src/max.p4
@@ -5,7 +5,7 @@
 #include "parser.p4"
 #include "ipv4_checksum.p4"
 
-#define CPU_MIRROR_SESSION_ID 1023
+#define CPU_MIRROR_SESSION_ID 511
 #define METER_GREEN 0
 
 


### PR DESCRIPTION
Tested on the AS7712. No changes, clone session are not yet supported by the FPM target.

Closes #12 

